### PR TITLE
2020 updates

### DIFF
--- a/robocup/custom-script.sh
+++ b/robocup/custom-script.sh
@@ -7,55 +7,12 @@ set -eux
 
 # Install needed dependencies
 sudo apt-get update
-sudo apt-get install -y git qtcreator
-
-# Install sideloaded requested things
-sudo apt-get install -y libopencv-dev
 
 # Make sure we are using the vagrant user
 su vagrant << EOF
-# CD to home dir
-cd
-# Clone all needed projects
-git clone https://github.com/RoboJackets/robocup-software.git
-git clone https://github.com/RoboJackets/robocup-firmware.git
-git clone https://github.com/RoboCup-SSL/ssl-refbox.git
 
-git -C robocup-software submodule update --init --recursive
-git -C robocup-firmware submodule update --init --recursive
-git -C ssl-refbox submodule update --init --recursive
-
-# Install software dependencies
-./robocup-software/util/ubuntu-setup --yes
-
-# Install firmware dependencies
-./robocup-firmware/util/ubuntu-setup --yes
-
-# Install refbox dependencies
-sudo apt-get install -y g++ git libgtkmm-2.4-dev libprotobuf-dev protobuf-compiler
-
-# Compile things
-cd robocup-software
-make
-
-
-# Install git hooks for robocup-software
-cp util/git-hooks/* .git/hooks/
-
-cd ../robocup-firmware
-
-# make robot2015
-cd ../ssl-refbox
-make
-cd rcon-client
-make
-cd ../
-sudo chown vagrant:vagrant -R ./robocup-software/external
-sudo chown vagrant:vagrant -R ./robocup-firmware/external
-cd ../
-EOF
-
-# Sublime :/
-sudo add-apt-repository ppa:webupd8team/sublime-text-3
+# Install Sublime Text 3
+wget -qO - https://download.sublimetext.com/sublimehq-pub.gpg | sudo apt-key add -
+echo "deb https://download.sublimetext.com/ apt/stable/" | sudo tee /etc/apt/sources.list.d/sublime-text.list
 sudo apt-get update
-sudo apt-get install -y sublime-text-installer
+sudo apt-get -y install sublime-text

--- a/robocup/tpl/vagrantfile-ubuntu1804-desktop.tpl
+++ b/robocup/tpl/vagrantfile-ubuntu1804-desktop.tpl
@@ -1,0 +1,33 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+    config.vm.define "vagrant-ubuntu1804-desktop"
+    config.vm.box = "ubuntu1804-desktop"
+
+    config.vm.provider :virtualbox do |v, override|
+        v.gui = true
+        v.customize ["modifyvm", :id, "--memory", 2048]
+        v.customize ["modifyvm", :id, "--cpus", 1]
+        v.customize ["modifyvm", :id, "--vram", "128"]
+        v.customize ["setextradata", "global", "GUI/MaxGuestResolution", "any"]
+        v.customize ["setextradata", :id, "CustomVideoMode1", "1024x768x32"]
+        v.customize ["modifyvm", :id, "--ioapic", "on"]
+        v.customize ["modifyvm", :id, "--rtcuseutc", "on"]
+        v.customize ["modifyvm", :id, "--accelerate3d", "on"]
+        v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
+    end
+
+    ["vmware_fusion", "vmware_workstation"].each do |provider|
+      config.vm.provider provider do |v, override|
+        v.gui = true
+        v.vmx["memsize"] = "1024"
+        v.vmx["numvcpus"] = "1"
+        v.vmx["cpuid.coresPerSocket"] = "1"
+        v.vmx["RemoteDisplay.vnc.enabled"] = "false"
+        v.vmx["RemoteDisplay.vnc.port"] = "5900"
+        v.vmx["scsi0.virtualDev"] = "lsilogic"
+        v.vmx["mks.enable3d"] = "TRUE"
+      end
+    end
+end

--- a/robocup/tpl/vagrantfile-ubuntu2004-desktop.tpl
+++ b/robocup/tpl/vagrantfile-ubuntu2004-desktop.tpl
@@ -1,0 +1,33 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+    config.vm.define "vagrant-ubuntu2004-desktop"
+    config.vm.box = "ubuntu2004-desktop"
+
+    config.vm.provider :virtualbox do |v, override|
+        v.gui = true
+        v.customize ["modifyvm", :id, "--memory", 2048]
+        v.customize ["modifyvm", :id, "--cpus", 1]
+        v.customize ["modifyvm", :id, "--vram", "128"]
+        v.customize ["setextradata", "global", "GUI/MaxGuestResolution", "any"]
+        v.customize ["setextradata", :id, "CustomVideoMode1", "1024x768x32"]
+        v.customize ["modifyvm", :id, "--ioapic", "on"]
+        v.customize ["modifyvm", :id, "--rtcuseutc", "on"]
+        v.customize ["modifyvm", :id, "--accelerate3d", "on"]
+        v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
+    end
+
+    ["vmware_fusion", "vmware_workstation"].each do |provider|
+      config.vm.provider provider do |v, override|
+        v.gui = true
+        v.vmx["memsize"] = "1024"
+        v.vmx["numvcpus"] = "1"
+        v.vmx["cpuid.coresPerSocket"] = "1"
+        v.vmx["RemoteDisplay.vnc.enabled"] = "false"
+        v.vmx["RemoteDisplay.vnc.port"] = "5900"
+        v.vmx["scsi0.virtualDev"] = "lsilogic"
+        v.vmx["mks.enable3d"] = "TRUE"
+      end
+    end
+end

--- a/robocup/ubuntu.json
+++ b/robocup/ubuntu.json
@@ -26,7 +26,6 @@
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -72,7 +71,6 @@
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -118,7 +116,6 @@
       "guest_os_type": "{{ user `parallels_guest_os_type` }}",
       "http_directory": "http",
       "iso_checksum": "{{ user `iso_checksum` }}",
-      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
       "iso_urls": [
         "{{ user `iso_path` }}/{{ user `iso_name` }}",
         "{{ user `iso_url` }}"
@@ -196,21 +193,19 @@
     "cpus": "1",
     "custom_script": ".",
     "desktop": "false",
-    "disk_size": "65536",
+    "disk_size": "15536",
     "docker": "false",
     "ftp_proxy": "{{env `ftp_proxy`}}",
     "headless": "true",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
     "install_vagrant_key": "true",
-    "iso_checksum": "70db69379816b91eb01559212ae474a36ecec9ef",
-    "iso_checksum_type": "sha1",
-    "iso_name": "ubuntu-16.04-server-amd64.iso",
-    "iso_path": "/Volumes/Storage/software/ubuntu",
-    "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04-server-amd64.iso",
-    "memory": "512",
+    "iso_checksum": "caf3fd69c77c439f162e2ba6040e9c320c4ff0d69aad1340a514319a9264df9f",
+    "iso_name": "ubuntu-20.04-legacy-server-amd64.iso",
+    "iso_url": "https://releases.ubuntu.com/20.04/ubuntu-20.04-live-server-amd64.iso",
+    "memory": "2048",
     "no_proxy": "{{env `no_proxy`}}",
-    "parallels_guest_os_type": "ubuntu",
+    "parallels_guest_os_type": "Ubuntu_64",
     "preseed" : "preseed.cfg",
     "rsync_proxy": "{{env `rsync_proxy`}}",
     "hostname": "vagrant",
@@ -221,7 +216,7 @@
     "vagrantfile_template": "",
     "version": "0.1.0",
     "virtualbox_guest_os_type": "Ubuntu_64",
-    "vm_name": "ubuntu1404",
+    "vm_name": "ubuntu2004",
     "vmware_guest_os_type": "ubuntu-64"
   }
 }

--- a/robocup/ubuntu1804-desktop.json
+++ b/robocup/ubuntu1804-desktop.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "Build with `packer build -var-file=ubuntu1804-desktop.json ubuntu.json`",
+  "vm_name": "ubuntu1804-desktop",
+  "desktop": "true",
+  "locale": "en_US.UTF-8",
+  "cpus": "1",
+  "disk_size": "130048",
+  "iso_checksum": "7d8e0055d663bffa27c1718685085626cb59346e7626ba3d3f476322271f573e",
+  "iso_checksum_type": "sha256",
+  "iso_name": "ubuntu-18.04.3-server-amd64.iso",
+  "iso_url": "http://cdimage.ubuntu.com/ubuntu/releases/18.04.3/release/ubuntu-18.04.3-server-amd64.iso",
+  "memory": "2048",
+  "preseed" : "preseed-desktop.cfg",
+  "vagrantfile_template": "tpl/vagrantfile-ubuntu1804-desktop.tpl"
+}

--- a/robocup/ubuntu1804.json
+++ b/robocup/ubuntu1804.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Build with `packer build -var-file=ubuntu1804.json ubuntu.json`",
+  "vm_name": "ubuntu1804",
+  "cpus": "1",
+  "disk_size": "65536",
+  "iso_checksum": "7d8e0055d663bffa27c1718685085626cb59346e7626ba3d3f476322271f573e",
+  "iso_checksum_type": "sha256",
+  "iso_name": "ubuntu-18.04.3-server-amd64.iso",
+  "iso_url": "http://cdimage.ubuntu.com/ubuntu/releases/18.04.3/release/ubuntu-18.04.3-server-amd64.iso",
+  "memory": "2048",
+  "preseed" : "preseed.cfg"
+}

--- a/robocup/ubuntu2004-desktop.json
+++ b/robocup/ubuntu2004-desktop.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "Build with `packer build -var-file=ubuntu1804-desktop.json ubuntu.json`",
+  "vm_name": "ubuntu2004-desktop",
+  "desktop": "true",
+  "locale": "en_US.UTF-8",
+  "cpus": "1",
+  "disk_size": "130048",
+  "iso_checksum": "36f15879bd9dfd061cd588620a164a82972663fdd148cce1f70d57d314c21b73",
+  "iso_name": "ubuntu-20.04-legacy-server-amd64.iso",
+  "iso_url": "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04-legacy-server-amd64.iso",
+  "memory": "2048",
+  "preseed" : "preseed-desktop.cfg",
+  "vagrantfile_template": "tpl/vagrantfile-ubuntu2004-desktop.tpl"
+}


### PR DESCRIPTION
Adds configuration files for Ubuntu 18.04 and 20.04 and sets defaults to build the VM for 20.04.

Also changes the install script to only install Sublime Text as a test until we get around to finding a way to automate the installation of every team's repo.

Some time after merging this pull request I will probably go back through and remove the split between the Robocup and IGVC folders so we have one definitive image. Also I need to add a Readme explaining some of the stuff I learned while working with the system